### PR TITLE
Fix URL logo & bold texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a src='https://www.onesaitplatform.com/'>
-    <img src='https://github.com/onesaitplatform/onesaitplatform-cloud/tree/master/resources/images/onesait-platform-logo.png' />
+    <img src='https://raw.githubusercontent.com/onesaitplatform/onesaitplatform-cloud/master/resources/images/onesait-platform-logo.png' />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a src='https://www.onesaitplatform.com/'>
-    <img src='../../resources/images/onesait-platform-logo.png'/>
+    <img src='/onesaitplatform/onesaitplatform-cloud/resources/images/onesait-platform-logo.png'/>
   </a>
 </p>
 
@@ -9,16 +9,16 @@
 This section includes examples showing different uses of the platform.
 Let´s see:
 
-* ** android-health-data-example **: example Android application in which a patient gives permission to a specific doctor to consult their medical data (modeled as an ontology) and once reviewed the doctor's permission is revoked
-* ** binary-ontology-example ** Java application that shows how to create ontologies with support for binaries (images) and how to insert this binary
-* ** chatbot ** example of Bot web able to answer different questions about environmental quality in Helsinki via NLP techniques.
-* ** device-simulator-example ** sample Java application that simulates inserts just like a device would
-* ** digitaltwin-sensehat ** modeling example of a SenseHat as Digital Twin platform. The example has the 2 parts: the execution of the Digital Twin of the SenseHat as Java application and an HTML5 application that allows to interact with the Digital Twin
-* ** example-issue-management ** HTML5 Web application that simulates incident management in a city, the citizen can create incidents, upload associated images and see the status of these, and the incidents system manager can process them.
-* ** example-notebook-rest-bubblemap ** HTML5 page that invokes a Notebook by its identifier and with the results obtained in the invocation paints a BubbleMap map representing the number of flights from an airport to the rest of the world
-* ** oauth2-authentication ** HTML5 page showing the OAuth2 flow allowing: (1) authenticate a user / password by obtaining their OAuth2 token, (2) obtain the APIS REST list of that user with their token and (3) invoke to an API with the token
-* ** quality-air **: HTML5 page that extracts air quality information from several cities
-* ** scheduler-example ** example module demonstrating how a module can be built that has to access the platform scheduling system
-* ** spring-boot-admin-metrics-example ** example module that shows how to create metrics that are then displayed in the platform monitoring module
-* ** streaming-twitter-module ** example module capable of listening to Twitter streams as they are configured on the platform. It has its equivalent part in the ControlPanel and in the ConfigDB.
+* **android-health-data-example**: example Android application in which a patient gives permission to a specific doctor to consult their medical data (modeled as an ontology) and once reviewed the doctor's permission is revoked
+* **binary-ontology-example**. Java application that shows how to create ontologies with support for binaries (images) and how to insert this binary
+* **chatbot**. example of Bot web able to answer different questions about environmental quality in Helsinki via NLP techniques.
+* **device-simulator-example**. sample Java application that simulates inserts just like a device would
+* **digitaltwin-sensehat**. modeling example of a SenseHat as Digital Twin platform. The example has the 2 parts: the execution of the Digital Twin of the SenseHat as Java application and an HTML5 application that allows to interact with the Digital Twin
+* **example-issue-management**. HTML5 Web application that simulates incident management in a city, the citizen can create incidents, upload associated images and see the status of these, and the incidents system manager can process them.
+* **example-notebook-rest-bubblemap**. HTML5 page that invokes a Notebook by its identifier and with the results obtained in the invocation paints a BubbleMap map representing the number of flights from an airport to the rest of the world
+* **oauth2-authentication**. HTML5 page showing the OAuth2 flow allowing: (1) authenticate a user / password by obtaining their OAuth2 token, (2) obtain the APIS REST list of that user with their token and (3) invoke to an API with the token
+* **quality-air**. HTML5 page that extracts air quality information from several cities
+* **scheduler-example**. example module demonstrating how a module can be built that has to access the platform scheduling system
+* **spring-boot-admin-metrics-example**. example module that shows how to create metrics that are then displayed in the platform monitoring module
+* **streaming-twitter-module**. example module capable of listening to Twitter streams as they are configured on the platform. It has its equivalent part in the ControlPanel and in the ConfigDB.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a src='https://www.onesaitplatform.com/'>
-    <img src='/onesaitplatform/onesaitplatform-cloud/resources/images/onesait-platform-logo.png'/>
+    <img src='http://github.com/onesaitplatform/onesaitplatform-cloud/resources/images/onesait-platform-logo.png'/>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a src='https://www.onesaitplatform.com/'>
-    <img src='http://github.com/onesaitplatform/onesaitplatform-cloud/resources/images/onesait-platform-logo.png'/>
+    <img src='https://github.com/onesaitplatform/onesaitplatform-cloud/tree/master/resources/images/onesait-platform-logo.png' />
   </a>
 </p>
 


### PR DESCRIPTION
- URL logo was linked to a wrong URL image.
- Bold texts in README.md was wrong typed following MarkDown style.